### PR TITLE
Improve poll UI

### DIFF
--- a/src/app/poll/[pollId]/page.tsx
+++ b/src/app/poll/[pollId]/page.tsx
@@ -6,34 +6,14 @@ import { useEffect } from "react";
 import { useQuery } from "convex/react";
 import { useMiniApp } from "@neynar/react";
 import { useParams, notFound } from "next/navigation";
-import { CheckCircle, Users, Badge, Share2 } from "lucide-react";
-import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
-import { Button } from "~/components/ui/Button";
-import { ShareButton } from "~/components/ui/Share";
-import Link from "next/link";
+import { PollCard } from "~/components/poll/PollCard";
 import { api } from "../../../../convex/_generated/api";
 import { Id } from "../../../../convex/_generated/dataModel";
-import { APP_URL } from "~/lib/constants";
+import Link from "next/link";
 
 type PollPageParams = {
   pollId: string;
 };
-
-interface PollOption {
-  id: string;
-  text: string;
-  votes: number;
-}
-
-interface Poll {
-  _id: Id<"polls">;
-  title: string;
-  description: string;
-  options: PollOption[];
-  totalVotes: number;
-  creatorFid: string;
-  createdAt: number;
-}
 
 
 
@@ -44,10 +24,6 @@ export default function PollPage() {
 
   // Fetch poll and vote status using useQuery
   const poll = useQuery(api.polls.getPoll, pollId ? { pollId: pollId as Id<"polls"> } : "skip");
-  const voteStatus = useQuery(
-    api.polls.hasVoted,
-    userFid && pollId ? { pollId: pollId as Id<"polls">, userFid } : "skip"
-  );
 
   // Defer notFound() to useEffect to avoid render-time side effects
   useEffect(() => {
@@ -71,21 +47,6 @@ export default function PollPage() {
     return null; // This won't be reached due to useEffect, but kept for type safety
   }
 
-  const castConfig = {
-    text: `Check out this poll: ${poll.title || "Untitled"} on Flash Poll! @1 @2`,
-    bestFriends: true,
-    embeds: [
-      {
-        path: `/poll/${pollId}`,
-        imageUrl: async () => `${APP_URL}/api/opengraph-image?pollId=${pollId}`,
-      },
-    ],
-  };
-
-  const getPercentage = (votes: number, total: number): number => {
-    return total > 0 ? Math.round((votes / total) * 100) : 0;
-  };
-
   return (
     <div className="min-h-screen bg-gradient-to-br from-purple-50 via-white to-blue-50">
       <div className="bg-white/70 backdrop-blur-md border-b border-purple-100 sticky top-0 z-10">
@@ -101,77 +62,7 @@ export default function PollPage() {
         </div>
       </div>
       <div className="container mx-auto px-4 py-8">
-        <Card className="w-full max-w-2xl mx-auto bg-white/80 backdrop-blur-sm border-0 shadow-xl">
-          <CardHeader className="pb-4">
-            <div className="flex items-start justify-between gap-4">
-              <div className="flex-1">
-                <CardTitle className="text-xl font-bold text-gray-900 leading-tight">
-                  {poll.title}
-                </CardTitle>
-                <p className="text-gray-600 mt-2 text-sm">{poll.description}</p>
-              </div>
-              <Badge className="bg-purple-100 text-purple-700 hover:bg-purple-200 transition-colors shrink-0">
-                <Users className="w-3 h-3 mr-1" />
-                {poll.totalVotes}
-              </Badge>
-            </div>
-          </CardHeader>
-          <CardContent className="space-y-3">
-            {poll.options.map((option: PollOption, index: number) => {
-              const percentage = getPercentage(option.votes, poll.totalVotes);
-              const isUserVote = voteStatus?.userVote === option.id;
-
-              return (
-                <div key={option.id} className="space-y-2">
-                  <div className="flex items-center justify-between">
-                    <span className="text-sm font-medium text-gray-700">{option.text}</span>
-                    <div className="flex items-center gap-2">
-                      <span className="text-xs text-gray-500">{option.votes.toLocaleString()} votes</span>
-                      <span className="text-sm font-semibold text-purple-600">{percentage}%</span>
-                      {isUserVote && <CheckCircle className="w-4 h-4 text-green-500" />}
-                    </div>
-                  </div>
-                  <div className="relative">
-                    <div className="w-full bg-gray-200 rounded-full h-3 overflow-hidden">
-                      <div
-                        className={`h-full rounded-full transition-all duration-1000 ease-out ${
-                          isUserVote ? "bg-gradient-to-r from-green-400 to-green-500" : "bg-gradient-to-r from-purple-400 to-purple-500"
-                        }`}
-                        style={{
-                          width: `${percentage}%`,
-                          animationDelay: `${index * 100}ms`,
-                        }}
-                      />
-                    </div>
-                  </div>
-                </div>
-              );
-            })}
-            {voteStatus?.hasVoted && (
-              <div className="mt-6 p-4 bg-green-50 rounded-xl border border-green-200">
-                <div className="flex items-center gap-2 text-green-700">
-                  <CheckCircle className="w-5 h-5" />
-                  <span className="font-medium">Thank you for voting!</span>
-                </div>
-                <p className="text-sm text-green-600 mt-1">Your vote has been recorded. Results are updated in real-time.</p>
-              </div>
-            )}
-            <div className="mt-4 flex gap-2">
-              <Link href="/" className="flex-1">
-                <Button className="w-full bg-gray-500 hover:bg-gray-600">Back to All Polls</Button>
-              </Link>
-              <ShareButton
-                buttonText="Share Poll"
-                cast={castConfig}
-                className="flex-1 bg-gradient-to-r from-green-500 to-green-600 hover:from-green-600 hover:to-green-700 text-white"
-                isLoading={false}
-              >
-                <Share2 className="w-4 h-4 mr-2" />
-                Share Poll
-              </ShareButton>
-            </div>
-          </CardContent>
-        </Card>
+        <PollCard poll={poll} userFid={userFid} showShareButton />
       </div>
       <div className="bg-white/50 backdrop-blur-sm border-t border-purple-100 mt-16">
         <div className="container mx-auto px-4 py-8 text-center">

--- a/src/components/Demo.tsx
+++ b/src/components/Demo.tsx
@@ -21,6 +21,7 @@ import { useMiniApp } from "@neynar/react";
 import { APP_NAME, APP_URL } from "~/lib/constants";
 import { Card, CardContent, CardHeader, CardTitle } from "./ui/card";
 import Link from "next/link";
+import { PollCard } from "./poll/PollCard";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "~/components/ui/dialog";
 import { Input } from "~/components/ui/input";
 import { Textarea } from "~/components/ui/textarea";
@@ -49,7 +50,6 @@ export default function Demo({ title = "Flash Poll" }: { title?: string }) {
   const [createPollError, setCreatePollError] = useState<string | null>(null);
   const [sharedCast, setSharedCast] = useState<any | null>(null);
   const [isShareContext, setIsShareContext] = useState(false);
-  const [shareError, setShareError] = useState<string | null>(null);
 
   const { address, isConnected } = useAccount();
   const chainId = useChainId();
@@ -250,146 +250,6 @@ export default function Demo({ title = "Flash Poll" }: { title?: string }) {
     }
   };
 
-  const getPercentage = (votes: number, total: number): number => {
-    return total > 0 ? Math.round((votes / total) * 100) : 0;
-  };
-
-  const PollCard = ({ poll }: { poll: any }) => {
-    const userFid = context?.user?.fid?.toString();
-    const voteStatus = useQuery(
-      api.polls.hasVoted,
-      userFid ? { pollId: poll._id, userFid } : "skip"
-    );
-    const isVoting = votingStates[poll._id] || false;
-
-    const castConfig = {
-      text: `Check out this poll: ${poll.title} on Flash Poll! @1 @2`,
-      bestFriends: true,
-      embeds: [
-        {
-          path: `/poll/${poll._id}`,
-          imageUrl: async () => `${APP_URL}/api/opengraph-image?pollId=${poll._id}`,
-        },
-      ],
-    };
-
-    return (
-      <Card className="w-full max-w-2xl mx-auto bg-white/80 backdrop-blur-sm border-0 shadow-xl hover:shadow-2xl transition-all duration-300 hover:-translate-y-1">
-        <CardHeader className="pb-4">
-          <div className="flex items-start justify-between gap-4">
-            <div className="flex-1">
-              <Link href={`/poll/${poll._id}`}>
-                <CardTitle className="text-xl font-bold text-gray-900 leading-tight hover:underline">
-                  {poll.title}
-                </CardTitle>
-              </Link>
-              <p className="text-gray-600 mt-2 text-sm">{poll.description}</p>
-            </div>
-            <Badge className="bg-purple-100 text-purple-700 hover:bg-purple-200 transition-colors shrink-0">
-              <Users className="w-3 h-3 mr-1" />
-              {poll.totalVotes.toLocaleString()}
-            </Badge>
-          </div>
-        </CardHeader>
-        <CardContent className="space-y-3">
-          {poll.options.map((option: any, index: number) => {
-            const percentage = getPercentage(option.votes, poll.totalVotes);
-            const isUserVote = voteStatus?.userVote === option.id;
-
-            return (
-              <div key={option.id} className="space-y-2">
-                <div className="flex items-center justify-between">
-                  <span className="text-sm font-medium text-gray-700">
-                    {option.text}
-                  </span>
-                  {voteStatus?.hasVoted && (
-                    <div className="flex items-center gap-2">
-                      <span className="text-xs text-gray-500">
-                        {option.votes.toLocaleString()} votes
-                      </span>
-                      <span className="text-sm font-semibold text-purple-600">
-                        {percentage}%
-                      </span>
-                      {isUserVote && (
-                        <CheckCircle className="w-4 h-4 text-green-500" />
-                      )}
-                    </div>
-                  )}
-                </div>
-                {voteStatus?.hasVoted ? (
-                  <div className="relative">
-                    <div className="w-full bg-gray-200 rounded-full h-3 overflow-hidden">
-                      <div
-                        className={`h-full rounded-full transition-all duration-1000 ease-out ${
-                          isUserVote
-                            ? "bg-gradient-to-r from-green-400 to-green-500"
-                            : "bg-gradient-to-r from-purple-400 to-purple-500"
-                        }`}
-                        style={{
-                          width: `${percentage}%`,
-                          animationDelay: `${index * 100}ms`,
-                        }}
-                      />
-                    </div>
-                  </div>
-                ) : (
-                  <Button
-                    onClick={() => handleVote(poll._id, option.id)}
-                    disabled={isVoting || !userFid}
-                    className="w-full bg-gradient-to-r from-purple-500 to-purple-600 hover:from-purple-600 hover:to-purple-700 text-white border-0 h-12 rounded-xl font-medium transition-all duration-200 hover:scale-[1.02] active:scale-[0.98] disabled:opacity-50 disabled:cursor-not-allowed disabled:transform-none"
-                  >
-                    {isVoting ? (
-                      <div className="flex items-center gap-2">
-                        <div className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
-                        Voting...
-                      </div>
-                    ) : (
-                      <div className="flex items-center gap-2">
-                        <TrendingUp className="w-4 h-4" />
-                        Vote for {option.text}
-                      </div>
-                    )}
-                  </Button>
-                )}
-              </div>
-            );
-          })}
-          {voteStatus?.hasVoted && (
-            <div className="mt-6 p-4 bg-green-50 rounded-xl border border-green-200">
-              <div className="flex items-center gap-2 text-green-700">
-                <CheckCircle className="w-5 h-5" />
-                <span className="font-medium">Thank you for voting!</span>
-              </div>
-              <p className="text-sm text-green-600 mt-1">
-                Your vote has been recorded. Results are updated in real-time.
-              </p>
-            </div>
-          )}
-          <div className="mt-4 flex gap-2">
-            <ShareButton
-              buttonText="Share Poll"
-              cast={castConfig}
-              className="flex-1 bg-gradient-to-r from-green-500 to-green-600 hover:from-green-600 hover:to-green-700 text-white"
-              isLoading={false}
-            />
-            {!context?.user?.fid && (
-              <Button
-                onClick={() => setShareError("Please sign in with Farcaster to share")}
-                className="hidden"
-                tabIndex={-1}
-                aria-hidden="true"
-              >
-                Hidden
-              </Button>
-            )}
-            {shareError && (
-              <p className="text-red-500 text-sm mt-2">{shareError}</p>
-            )}
-          </div>
-        </CardContent>
-      </Card>
-    );
-  };
 
   if (!isSDKLoaded) {
     return <div>Loading...</div>;
@@ -460,7 +320,7 @@ export default function Demo({ title = "Flash Poll" }: { title?: string }) {
       <div className="container mx-auto px-4 py-8">
         <div className="space-y-8">
           {polls.length > 0 ? (
-            polls.map((poll) => <PollCard key={poll._id} poll={poll} />)
+            polls.map((poll) => <PollCard key={poll._id} poll={poll} userFid={context?.user?.fid?.toString()} onVote={handleVote} isVoting={votingStates[poll._id]} />)
           ) : (
             <p className="text-center text-gray-500">No polls available.</p>
           )}

--- a/src/components/Demo.tsx
+++ b/src/components/Demo.tsx
@@ -22,6 +22,7 @@ import { APP_NAME, APP_URL } from "~/lib/constants";
 import { Card, CardContent, CardHeader, CardTitle } from "./ui/card";
 import Link from "next/link";
 import { PollCard } from "./poll/PollCard";
+import { PollCardSkeleton } from "./poll/PollCardSkeleton";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "~/components/ui/dialog";
 import { Input } from "~/components/ui/input";
 import { Textarea } from "~/components/ui/textarea";
@@ -55,7 +56,7 @@ export default function Demo({ title = "Flash Poll" }: { title?: string }) {
   const chainId = useChainId();
 
   // Convex queries and mutations
-  const polls = useQuery(api.polls.getAllPolls, { limit: 10 }) || [];
+  const polls = useQuery(api.polls.getAllPolls, { limit: 10 });
   const addOrUpdateUser = useMutation(api.users.addOrUpdateUser);
   const voteMutation = useMutation(api.polls.vote);
   const createPollMutation = useMutation(api.polls.createPoll);
@@ -319,8 +320,20 @@ export default function Demo({ title = "Flash Poll" }: { title?: string }) {
       </div>
       <div className="container mx-auto px-4 py-8">
         <div className="space-y-8">
-          {polls.length > 0 ? (
-            polls.map((poll) => <PollCard key={poll._id} poll={poll} userFid={context?.user?.fid?.toString()} onVote={handleVote} isVoting={votingStates[poll._id]} />)
+          {polls === undefined ? (
+            Array.from({ length: 3 }).map((_, i) => (
+              <PollCardSkeleton key={i} />
+            ))
+          ) : polls.length > 0 ? (
+            polls.map((poll) => (
+              <PollCard
+                key={poll._id}
+                poll={poll}
+                userFid={context?.user?.fid?.toString()}
+                onVote={handleVote}
+                isVoting={votingStates[poll._id]}
+              />
+            ))
           ) : (
             <p className="text-center text-gray-500">No polls available.</p>
           )}

--- a/src/components/poll/PollCard.tsx
+++ b/src/components/poll/PollCard.tsx
@@ -1,0 +1,167 @@
+import { useQuery } from "convex/react";
+import Link from "next/link";
+import { CheckCircle, TrendingUp, Users } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
+import { Badge } from "../ui/badge";
+import { Button } from "../ui/Button";
+import { ShareButton } from "../ui/Share";
+import { api } from "../../convex/_generated/api";
+import { Id } from "../../convex/_generated/dataModel";
+import { APP_URL } from "~/lib/constants";
+
+type PollOption = {
+  id: string;
+  text: string;
+  votes: number;
+};
+
+export interface Poll {
+  _id: Id<"polls">;
+  title: string;
+  description: string;
+  options: PollOption[];
+  totalVotes: number;
+  creatorFid: string;
+  createdAt: number;
+}
+
+interface PollCardProps {
+  poll: Poll;
+  userFid?: string | null;
+  onVote?: (pollId: Id<"polls">, optionId: string) => void;
+  isVoting?: boolean;
+  showShareButton?: boolean;
+}
+
+export function PollCard({ poll, userFid, onVote, isVoting = false, showShareButton = false }: PollCardProps) {
+  const voteStatus = useQuery(
+    api.polls.hasVoted,
+    userFid ? { pollId: poll._id, userFid } : "skip"
+  );
+
+  const castConfig = {
+    text: `Check out this poll: ${poll.title} on Flash Poll! @1 @2`,
+    bestFriends: true,
+    embeds: [
+      {
+        path: `/poll/${poll._id}`,
+        imageUrl: async () => `${APP_URL}/api/opengraph-image?pollId=${poll._id}`,
+      },
+    ],
+  };
+
+  const getPercentage = (votes: number, total: number): number =>
+    total > 0 ? Math.round((votes / total) * 100) : 0;
+
+  const showResults = voteStatus?.hasVoted || !onVote;
+
+  return (
+    <Card className="w-full max-w-2xl mx-auto bg-white/80 backdrop-blur-sm border-0 shadow-xl hover:shadow-2xl transition-all duration-300 hover:-translate-y-1">
+      <CardHeader className="pb-4">
+        <div className="flex items-start justify-between gap-4">
+          <div className="flex-1">
+            <Link href={`/poll/${poll._id}`}>
+              <CardTitle className="text-xl font-bold text-gray-900 leading-tight hover:underline">
+                {poll.title}
+              </CardTitle>
+            </Link>
+            <p className="text-gray-600 mt-2 text-sm">{poll.description}</p>
+          </div>
+          <Badge className="bg-purple-100 text-purple-700 hover:bg-purple-200 transition-colors shrink-0">
+            <Users className="w-3 h-3 mr-1" />
+            {poll.totalVotes.toLocaleString()}
+          </Badge>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {poll.options.map((option, index) => {
+          const percentage = getPercentage(option.votes, poll.totalVotes);
+          const isUserVote = voteStatus?.userVote === option.id;
+
+          return (
+            <div key={option.id} className="space-y-2">
+              <div className="flex items-center justify-between">
+                <span className="text-sm font-medium text-gray-700">{option.text}</span>
+                {showResults && (
+                  <div className="flex items-center gap-2">
+                    <span className="text-xs text-gray-500">
+                      {option.votes.toLocaleString()} votes
+                    </span>
+                    <span className="text-sm font-semibold text-purple-600">
+                      {percentage}%
+                    </span>
+                    {isUserVote && <CheckCircle className="w-4 h-4 text-green-500" />}
+                  </div>
+                )}
+              </div>
+              {showResults ? (
+                <div className="relative">
+                  <div className="w-full bg-gray-200 rounded-full h-3 overflow-hidden">
+                    <div
+                      className={`h-full rounded-full transition-all duration-1000 ease-out ${
+                        isUserVote
+                          ? "bg-gradient-to-r from-green-400 to-green-500"
+                          : "bg-gradient-to-r from-purple-400 to-purple-500"
+                      }`}
+                      style={{ width: `${percentage}%`, animationDelay: `${index * 100}ms` }}
+                    />
+                  </div>
+                </div>
+              ) : (
+                <Button
+                  onClick={() => onVote && onVote(poll._id, option.id)}
+                  disabled={isVoting || !userFid}
+                  className="w-full bg-gradient-to-r from-purple-500 to-purple-600 hover:from-purple-600 hover:to-purple-700 text-white border-0 h-12 rounded-xl font-medium transition-all duration-200 hover:scale-[1.02] active:scale-[0.98] disabled:opacity-50 disabled:cursor-not-allowed disabled:transform-none"
+                >
+                  {isVoting ? (
+                    <div className="flex items-center gap-2">
+                      <div className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+                      Voting...
+                    </div>
+                  ) : (
+                    <div className="flex items-center gap-2">
+                      <TrendingUp className="w-4 h-4" />
+                      Vote for {option.text}
+                    </div>
+                  )}
+                </Button>
+              )}
+            </div>
+          );
+        })}
+        {voteStatus?.hasVoted && (
+          <div className="mt-6 p-4 bg-green-50 rounded-xl border border-green-200">
+            <div className="flex items-center gap-2 text-green-700">
+              <CheckCircle className="w-5 h-5" />
+              <span className="font-medium">Thank you for voting!</span>
+            </div>
+            <p className="text-sm text-green-600 mt-1">Your vote has been recorded. Results are updated in real-time.</p>
+          </div>
+        )}
+        <div className="mt-4 flex gap-2">
+          {onVote && (
+            <ShareButton
+              buttonText="Share Poll"
+              cast={castConfig}
+              className="flex-1 bg-gradient-to-r from-green-500 to-green-600 hover:from-green-600 hover:to-green-700 text-white"
+              isLoading={false}
+            />
+          )}
+          {showShareButton && !onVote && (
+            <ShareButton
+              buttonText="Share Poll"
+              cast={castConfig}
+              className="flex-1 bg-gradient-to-r from-green-500 to-green-600 hover:from-green-600 hover:to-green-700 text-white"
+              isLoading={false}
+            />
+          )}
+          {!onVote && (
+            <Link href="/" className="flex-1">
+              <Button className="w-full bg-gray-500 hover:bg-gray-600">Back to All Polls</Button>
+            </Link>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/poll/PollCard.tsx
+++ b/src/components/poll/PollCard.tsx
@@ -5,8 +5,8 @@ import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
 import { Badge } from "../ui/badge";
 import { Button } from "../ui/Button";
 import { ShareButton } from "../ui/Share";
-import { api } from "../../convex/_generated/api";
-import { Id } from "../../convex/_generated/dataModel";
+import { api } from "../../../convex/_generated/api";
+import { Id } from "../../../convex/_generated/dataModel";
 import { APP_URL } from "~/lib/constants";
 
 type PollOption = {

--- a/src/components/poll/PollCardSkeleton.tsx
+++ b/src/components/poll/PollCardSkeleton.tsx
@@ -1,0 +1,17 @@
+import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
+
+export function PollCardSkeleton() {
+  return (
+    <Card className="w-full max-w-2xl mx-auto bg-white/80 backdrop-blur-sm border-0 shadow-xl animate-pulse">
+      <CardHeader>
+        <CardTitle className="h-6 bg-gray-200 rounded w-1/3" />
+        <div className="mt-2 h-4 bg-gray-200 rounded w-2/3" />
+      </CardHeader>
+      <CardContent className="space-y-2">
+        {Array.from({ length: 3 }).map((_, idx) => (
+          <div key={idx} className="h-10 bg-gray-200 rounded" />
+        ))}
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary
- create a reusable `PollCard` component for poll display and voting
- use `PollCard` on the poll results page and in the demo list
- remove duplicated UI code and cleanup old logic

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685823ec302883289c3972549b04a064